### PR TITLE
更新芙芙工具箱主页以适配最新独立开发工具包版本以及更新其开源许可文件总览

### DIFF
--- a/Tools/Fufu_Tools/index.html
+++ b/Tools/Fufu_Tools/index.html
@@ -111,63 +111,27 @@
             </div>
 
             <div class="container">
-                <p><i>最新正式版<a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/v1.3.3" target="_blank">v1.3.3</a>:</i></p>
                 <table>
                     <thead>
                         <tr>
-                            <th>版本类型</th>
-                            <th>下载链接</th>
+                            <th>类型</th>
+                            <th>正式版</th>
+                            <th>预览版</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td>lite版</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools.v1.3.3-lite.zip">Fufu_Tools.v1.3.3-lite.zip</a>
-                            </td>
+                            <td>工具箱</td>
+                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/tag/v1.3.3" target="_blank">v1.3.3</a></td>
+                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/tag/v1.3.3" target="_blank">v1.3.3</a></td>
                         </tr>
                         <tr>
-                            <td>lite版(7z)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools.v1.3.3-lite.7z">Fufu_Tools.v1.3.3-lite.7z</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>打包版(zip)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools.v1.3.3.zip">Fufu_Tools.v1.3.3.zip</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>打包版(7z)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools.v1.3.3.7z">Fufu_Tools.v1.3.3.7z</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>打包版(7z-极限压缩)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools.v1.3.3-Extreme_compression.7z">Fufu_Tools.v1.3.3-Extreme_compression.7z</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>安装程序(exe)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/download/v1.3.3/Fufu_Tools_Setup.v1.3.3.exe">Fufu_Tools_Setup.v1.3.3.exe</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>独立开发工具(zip)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2024.06.30.1356/Fufu_Tools_Dev_Tools_2024.06.30.1356.zip">Fufu_Tools_Dev_Tools_2024.06.30.1356.zip</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>独立开发工具(7z)</td>
-                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/download/2024.06.30.1356/Fufu_Tools_Dev_Tools_2024.06.30.1356.7z">Fufu_Tools_Dev_Tools_2024.06.30.1356.7z</a>
-                            </td>
+                            <td>开发工具包</td>
+                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2024.07.03.0000" target="_blank">2024.07.03.0000</a></td>
+                            <td><a href="https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2024.08.01.0000" target="_blank">2024.08.01.0000</a></td>
                         </tr>
                     </tbody>
                 </table>
-                <p><em>独立开发工具包版本<a href="https://github.com/DuckDuckStudio/Fufu_Dev_Tools/releases/tag/2024.06.30.1356">2024.06.30.1356</a></em></p>                
-                <p><i>最新预览版<a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/v1.3.3" target="_blank">v1.3.3</a>:</i></p>
-                <p>同最新正式版。</p>
-                <p><i>过往版本:</i></p>
-                <p><a href="https://github.com/DuckDuckStudio/Fufu_Tools/releases/" target="_blank">前往GitHub仓库Releases页下载</a></p>
-                <p><strong>警告: 最新版本以GitHub Releases页为准！</strong></p>
             </div>
 
             <div class="center-text">
@@ -214,7 +178,7 @@
                             <td><span style="color: #4493f8;">[!]</span> 遵守许可文件</td>
                         </tr>
                         <tr>
-                            <td><span style="color: #38a449;">✓</span> 发表</td>
+                            <td><span style="color: #38a449;">✓</span> 发表使用部分代码的程序</td>
                             <td><span style="color: #f85149;">✕</span> 将复制品提供给第三方</td>
                             <td><span style="color: #4493f8;">[!]</span> 标注原作者</td>
                         </tr>
@@ -229,7 +193,7 @@
                             <td><span style="color: #4493f8;">[!]</span> 司法管辖区位于 中国福建省厦门市</td>
                         </tr>
                         <tr>
-                            <td><span style="color: #38a449;">✓</span> 文章使用</td>
+                            <td></td>
                             <td><span style="color: #f85149;">✕</span> 使用部分著作权</td>
                             <td><span style="color: #4493f8;">[!]</span> 以最新版许可文件为准</td>
                         </tr>
@@ -241,14 +205,14 @@
                     </tbody>
                 </table>
                 <p><strong>本概览不作为最终协议内容，仅作简单总结。最终协议请查看<a href="https://github.com/DuckDuckStudio/Fufu_Tools/blob/main/LICENSE" target="_blank">LICENSE文件</a></strong> <span style="float: right;">许可文件最后更新:</span></p>
-                <p><strong>对于许可文件，以最新版为准，请注意许可文件更新公告！(见右侧→)</strong> <span style="float: right;">2024年5月21日 细化许可条款</span></p>
+                <p><strong>对于许可文件，以最新版为准，请注意许可文件更新公告！(见右侧→)</strong> <span style="float: right;">2024年8月3日 添加版权登记相关信息</span></p>
             </div>
         </div>
 
         <div class="container" style="margin-bottom: 1%; margin-right: 1%; margin-left: 1%;">
             <div class="right-text">
                 <a href="https://duckduckstudio.github.io/yazicbs.github.io/">回到主页</a>
-                <p>最后更新：<strong>2024/5/27</strong></p>
+                <p>最后更新：<strong>2024/8/3</strong></p>
                 <a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues" target="_blank">[提交<strong>本页面</strong>的反馈]</a><br>
                 <a href="https://github.com/DuckDuckStudio/Fufu_Tools/issues" target="_blank">[提交<strong>芙芙工具箱</strong>的反馈]</a><br>
             </div>


### PR DESCRIPTION
- https://github.com/DuckDuckStudio/Fufu_Tools/pull/95