### PR TITLE
fix: 修正一些 IDE 检查错误

### DIFF
--- a/Interesting/KFCfkThurVMe50.html
+++ b/Interesting/KFCfkThurVMe50.html
@@ -15,12 +15,12 @@
             let dayOfWeek = currentDate.getDay(); // 返回一周中的第几天，周日->0，周一->1...
             //---
             if (Math.random() > 0.5) {
-                window.location.href = 'https://www.cnhls.com/';// %50几率跳转华莱士官网(周四亦如此)
+                window.location.href = "https://www.cnhls.com/";// %50几率跳转华莱士官网(周四亦如此)
             } else { // 没随机到时
                 if (dayOfWeek === 4) { // 如果今天疯狂星期四
-                    window.location.href = 'http://www.kfc.com.cn/kfccda/index.aspx';
+                    window.location.href = "https://www.kfc.com.cn/kfccda/index.aspx";
                 } else {
-                    window.location.href = 'https://www.mcdonalds.com.cn/';
+                    window.location.href = "https://www.mcdonalds.com.cn/";
                 }
             }
         </script>

--- a/Interesting/鸭子活了多久/index.html
+++ b/Interesting/鸭子活了多久/index.html
@@ -13,7 +13,7 @@
     </head>
     <body>
         <div class="container">
-            <h1>我家<span id="name">嘎嘎</span><spen id="岁数类型">活了相当于人</spen></h1>
+            <h1>我家<span id="name">嘎嘎</span><span id="岁数类型">活了相当于人</span></h1>
             <p>&nbsp;</p>
             <p>
                 <span id="age">[计算中]</span>

--- a/Tools/Fufu_Tools/wiki/常见问题QandA/小工具/index.html
+++ b/Tools/Fufu_Tools/wiki/常见问题QandA/小工具/index.html
@@ -87,14 +87,14 @@ https://space.bilibili.com/2054654702/
                 <h2 id="error-module">Q:小工具运行时出现错误<code>No module named &#39;xxx&#39;</code> 或 打不开pyw文件且任务管理器中没python进程</h2>
                 <p><em>Note:此步骤需要联网</em><br>
                 A:<br>
-                如果你在运行小工具(lite版)时出现类似这样(<code>No module named &#39;xxx&#39;</code>)的错误，请安装缺失的库文件。<br>
-                <img src="https://duckduckstudio.github.io/Fufu_Tools/photos/%E7%BC%BA%E5%B0%91%E5%BA%93%E6%96%87%E4%BB%B6.png" alt="缺少库文件" width="70%" height="70%" ><br>
-                安装库文件以解决此问题：<br>
+                如果你在运行小工具(lite版)时出现类似这样(<code>No module named &#39;xxx&#39;</code>)的错误，请安装缺失的库文件。</p>
+                <img src="https://duckduckstudio.github.io/Fufu_Tools/photos/%E7%BC%BA%E5%B0%91%E5%BA%93%E6%96%87%E4%BB%B6.png" alt="缺少库文件" style="width: 70%; height: 70%;">
+                <p>安装库文件以解决此问题：</p>
                 <ol>
                     <li><p><code>cd</code>到芙芙工具箱目录</p></li>
                     <li><p>运行<code>pip install -r 环境配置/requirements.txt</code>(镜像源在命令后面加上<code>-i https://pypi.tuna.tsinghua.edu.cn/simple</code>) 命令</p></li>
                 </ol>
-                如果在安装完库文件后仍然无法运行小工具（在出现相同错误的情况下）或者你使用的是打包版本的小工具，请 <strong><a href="https://github.com/DuckDuckStudio/Fufu_Tools/issues">提交Issues</a></strong>。<br></p>
+                <p>如果在安装完库文件后仍然无法运行小工具（在出现相同错误的情况下）或者你使用的是打包版本的小工具，请 <strong><a href="https://github.com/DuckDuckStudio/Fufu_Tools/issues">提交Issues</a></strong>。</p>
             </div>
             <p>&nbsp;</p>
             <div class="container">
@@ -120,7 +120,7 @@ https://space.bilibili.com/2054654702/
                 <p>A:</p>
                 <p>方案1：</p>
                 <p>前往<a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/#files">芙芙工具箱文档的索引页面</a>下载对应的config.ini文件进行替换。</p>
-                <img src="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/photos/config文件.png" width="70%" height="70%" alt="img">
+                <img src="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/photos/config文件.png" style="width: 70%; height: 70%;" alt="配置文件下载位置截图">
                 <p>方案2：</p>
                 <p>前往<a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/#files">芙芙工具箱文档的索引页面</a>下载对应的重置config.py文件放到对应目录后执行。</p>           
             </div>

--- a/Tools/chinese_git/Spare-Download/Chinese_git.py
+++ b/Tools/chinese_git/Spare-Download/Chinese_git.py
@@ -12,7 +12,7 @@ exit_code = 0 # 只有不正常退出需要定义
 
 # ---------- 版本定义及更新 ----------
 # 定义版本号
-VERSION = 'v3.2'
+VERSION = 'v3.4'
 # GitHub releases API URL
 url = 'https://api.github.com/repos/DuckDuckStudio/Chinese_git/releases/latest'
 
@@ -247,120 +247,10 @@ def auto_update():
         else:
             print(f"{Fore.BLUE}[!]{Fore.RESET} 已跳过更新。")
 
-# ---------- 版本...更新 结束 ----------
-# ---------- 公告获取 -----------------
-notice_url = 'https://duckduckstudio.github.io/yazicbs.github.io/Tools/chinese_git/notice/notice.txt'
-previous_notice_file = os.path.join(script_path, 'previous_notice.txt')# 显示过的公告
+# ---------- 版本更新 结束 ----------
 
-def get_notice_content(url, manual=False):
+def git_command(command: str, args: list[str]):
     global exit_code
-    try:
-        response = requests.get(url)
-        if response.status_code == 200:
-            content = response.text
-            return content
-        else:
-            if manual:
-                print(f"{Fore.RED}✕{Fore.RESET} 获取最新公告失败！\n状态码: {Fore.BLUE}{response.status_code}{Fore.RESET}")
-                t = input(f"{Fore.BLUE}?{Fore.RESET} 是否读取本地最新公告({Fore.GREEN}是{Fore.RESET}/{Fore.RED}否{Fore.RESET}):").lower()
-                if t in ['是', 'y', 'yes']:
-                    display_notice('本地')
-                else:
-                    exit_code = 1
-            return None
-    except Exception as e:
-        if manual:
-            print(f"{Fore.RED}✕{Fore.RESET} 获取最新公告失败！\n错误信息: {Fore.RED}{e}{Fore.RESET}")
-            t = input(f"{Fore.BLUE}?{Fore.RESET} 是否读取本地最新公告({Fore.GREEN}是{Fore.RESET}/{Fore.RED}否{Fore.RESET}):").lower()
-            if t in ['是', 'y', 'yes']:
-                display_notice('本地')
-            else:
-                exit_code = 1
-        return None
-
-def save_previous_notice(content):
-    with open(previous_notice_file, 'w') as file:
-        file.write(content)
-
-def read_previous_notice():
-    try:
-        with open(previous_notice_file, 'r') as file:
-            return file.read()
-    except FileNotFoundError:
-        return ""
-    except Exception:
-        return "" # 以防出现像 microsoft/winget-pkgs #156224 中的错误
-
-def display_notice(manual=False):
-    global exit_code
-    if manual:
-        content = get_notice_content(notice_url, True)
-    elif not manual:
-        content = get_notice_content(notice_url)
-
-    if manual == "本地":
-        content = read_previous_notice()
-        if content == "":
-            print(f"{Fore.RED}✕{Fore.RESET} 没有本地公告")
-            exit_code = 1
-            return
-    else:
-        previous_notice = read_previous_notice()
-
-    if content:
-        try:
-            lines = content.split('\n')
-
-            # ---- 值提取 ----
-            level_line = lines[0].strip()
-            level = int(level_line.split(':')[1])
-            # -- 等级↑ 是否强制↓ --
-            force_line = lines[1].strip()
-            force = bool(force_line.split(':')[1])
-            # ----------------
-        except Exception as e:
-            if not manual:
-                return
-            else:
-                print(f"{Fore.RED}✕{Fore.RESET} 最新公告{Fore.YELLOW}不符合{Fore.RESET}规范，请联系开发者反馈！")
-                print(f"{Fore.RED}✕{Fore.RESET} 反馈时{Fore.YELLOW}请带上错误信息{Fore.RESET}:\n{Fore.RED}{e} | {Fore.CYAN}{level_line} {Fore.RED}|{Fore.CYAN} {force_line}{Fore.RESET}")
-                exit_code = 1
-                return
-
-        if level == 1:
-            color = Fore.RED
-        elif level == 2:
-            color = Fore.YELLOW
-        elif level == 3:
-            color = Fore.GREEN
-        elif level == 4:
-            color = Fore.BLUE
-        else:
-            color = ''
-
-        if manual:
-            print(f"{color}[!最新公告({level}级)!]{Fore.RESET}")
-            for line in lines[2:]:
-                print(line)
-            print(f"{color}[!------------!]{Fore.RESET}")
-        elif manual == "本地":
-            print(f"{color}[!最新本地公告({level}级)!]{Fore.RESET}")
-            for line in lines[2:]:
-                print(line)
-            print(f"{color}[!------------!]{Fore.RESET}")
-        else:
-            if content != previous_notice:
-                if force:
-                    print(f"\n{color}[!有新公告({level}级)!]{Fore.RESET}")
-                    for line in lines[2:]:
-                        print(line)
-                    print(f"{color}[!------------!]{Fore.RESET}")
-                save_previous_notice(content)
-# ---------- 公告获取 结束 ------------
-
-def git_command(command, *args):
-    global exit_code
-    args = list(args) # 统一类型
     git_command_mapping = {
         "拉取": ["git", "pull"],
         "推送": ["git", "push"],
@@ -387,7 +277,6 @@ def git_command(command, *args):
         # --- 特殊功能 ---
         "版本": ["git", "--version"],
         "更新": ["update"], # 没用到git
-        "公告": ["notice"], # 没用到git
         # --- 结束 ---
         "还原": ["git", "revert"],
         "重置": ["git", "reset"],
@@ -464,9 +353,6 @@ def git_command(command, *args):
                 print(f"版本: {Fore.BLUE}{VERSION}{Fore.RESET}")
                 print(f"安装在: {Fore.BLUE}{full_path}{Fore.RESET}")
                 result = subprocess.run(git_command, capture_output=True, text=True)
-            elif command == "公告":
-                display_notice(True)
-                return
             elif command == "还原":
                 if not args:
                     print(f"{Fore.RED}✕{Fore.RESET} 还原命令需要参数")
@@ -528,7 +414,7 @@ def git_command(command, *args):
                         print(f"{Fore.RED}✕{Fore.RESET} 新旧分支名称相同")
                         exit_code = 1
                     result = subprocess.run(git_command + [old_branch, new_branch], capture_output=True, text=True)
-                if args < 2:
+                if len(args) < 2:
                     print(f"{Fore.RED}✕{Fore.RESET} 缺少参数")
                     exit_code = 1
                 else:
@@ -587,33 +473,25 @@ def git_command(command, *args):
             
             if auto_check_update == "True":
                 always_check() # 自动检查更新
-            if auto_get_notice == "True":
-                display_notice() # 自动公告获取
         except Exception as e:
             print(f"{Fore.RED}✕{Fore.RESET} 执行命令时出错: {e}")
             if auto_check_update == "True":
                 always_check() # 自动检查更新
-            if auto_get_notice == "True":
-                display_notice() # 自动公告获取
             exit_code = 1
     else:
         print("不支持的命令:", command)
         if auto_check_update == "True":
             always_check() # 自动检查更新
-        if auto_get_notice == "True":
-            display_notice() # 自动公告获取
-            exit_code = 1
+        exit_code = 1
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        git_command(sys.argv[1], *sys.argv[2:])
+        git_command(sys.argv[1], sys.argv[2:])
     else:
         print("使用方法:")
         print("中文git <中文指令> [参数]")
         print("即: 中文git <你想干什么> [具体要啥]")
         if auto_check_update == "True":
             always_check() # 自动检查更新
-        if auto_get_notice == "True":
-            display_notice() # 自动公告获取
         exit_code = 1
 sys.exit(exit_code)

--- a/Tools/chinese_git/Spare-Download/info.json
+++ b/Tools/chinese_git/Spare-Download/info.json
@@ -1,4 +1,4 @@
 {
-  "release_date": "2025-02-28",
-  "version": "v3.2"
+  "release_date": "2025-06-16",
+  "version": "v3.4"
 }

--- a/zh_cn/debug.html
+++ b/zh_cn/debug.html
@@ -49,8 +49,6 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
         <!-- 定义网站的名称 -->
         <meta content="鸭鸭工作室的官方网站" property="og:description">
         <!-- 定义网页的描述，用于社交媒体分享时显示 -->
-        <meta content="鸭鸭工作室 | 鸭鸭「カモ」" itemprop="name">
-        <!-- 来自ChatGPT: itemprop 属性提供了与 og:title、og:description 和 og:image 相同的信息，用于标记页面上的结构化数据 -->
         <meta name="description" content="[鸭鸭工作室 | 鸭鸭「カモ」] 这是鸭鸭工作室(Duck Studio)的官方网站，你可以在这个网站上找到关于我的一些作品。">
         <!-- 优化对于bing的结果描述 -->
         <meta content="鸭鸭工作室,鸭鸭「カモ」,DuckStudio,Yzcbs,鸭子出版社" name="keywords">
@@ -112,7 +110,6 @@ https://space.bilibili.com/2054654702/
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.css">
         <div id="aplayer"></div>
         <script src="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.js"></script>
-        
         <script src="https://duckduckstudio.github.io/yazicbs.github.io/zh_cn/js/SongList.js"></script>
         <!-- END -->
         <div>
@@ -121,7 +118,6 @@ https://space.bilibili.com/2054654702/
                     <div class="css-2ezjh4 css-1mzqwyc0">
                         <div class="page-wrapper">
                             <ul class="slides s-page-1 " style="display: block; list-style-type: none;">
-                            <!-- 此处Visual Studio提示[元素"ul"需要结束标记]，但在第 1054 行已有结束标记。故忽略该警告。 -->
                                 <li class="slide s-section-1 s-first-visible-section css-3757m5">
                                     <div class="waypoint"></div>
                                     <a class="section-anchor"></a>
@@ -215,7 +211,7 @@ https://space.bilibili.com/2054654702/
                                                                         let typing = true;
 
                                                                         // 设置定时器，每200毫秒执行一次
-                                                                        setInterval(function() {
+                                                                        setInterval(function () {
                                                                             if (typing) {
                                                                                 // 正在打字状态，显示当前字符串的前charIndex个字符
                                                                                 text.innerHTML = currentOrder[currentIndex].slice(0, ++charIndex);
@@ -227,7 +223,7 @@ https://space.bilibili.com/2054654702/
                                                                             // 判断打字或删除字是否完成
                                                                             if (charIndex === currentOrder[currentIndex].length + 3) {
                                                                                 // 打字完成后停留时间较长（1000毫秒），然后切换到删除字状态
-                                                                                setTimeout(function() {
+                                                                                setTimeout(function () {
                                                                                     typing = false;
                                                                                 }, 1000);
                                                                             } else if (charIndex < 0) {
@@ -306,8 +302,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -718,10 +713,9 @@ https://space.bilibili.com/2054654702/
                                                                                             <strong>目前仅支持电脑端。</strong>
                                                                                         </p>
                                                                                         <p>
-                                                                                        <a href="https://duckduckstudio.github.io/yazicbs.github.io/Duck%20Parkour.html"
-                                                                                            target="_blank">在线试玩</a>
-                                                                                            </p>
-                                                                                        </div>
+                                                                                            <a href="https://duckduckstudio.github.io/yazicbs.github.io/Duck%20Parkour.html"
+                                                                                                target="_blank">在线试玩</a>
+                                                                                        </p>
                                                                                     </div>
                                                                                 </div>
                                                                             </div>
@@ -730,105 +724,102 @@ https://space.bilibili.com/2054654702/
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                        <!-- 展示块分界 -->
-                                                        <br>
-                                                        <div data-sorting-index="5" class="s-repeatable-item s-last-row">
-                                                            <div class="clearfix">
-                                                                <div>
-                                                                    <div
-                                                                        class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                        <div class="s-item-media-group">
-                                                                            <div class="s-component s-media">
-                                                                                <div>
-                                                                                    <div class="s-component-content">
-                                                                                        <div class="s-img-wrapper">
-                                                                                            <a href="https://scratch.mit.edu/projects/607666265"
-                                                                                                target="_blank">
-                                                                                                <div class="s-ratio-box"
-                                                                                                    style="max-width: 720px; max-height: 405px;">
-                                                                                                    <div class="s-ratio-fill"
-                                                                                                        style="padding-bottom: 56.25%;">
-                                                                                                    </div>
-                                                                                                    <div
-                                                                                                        class="s-img-wrapper">
-                                                                                                        <img alt="数字华容道的展示图"
-                                                                                                            class="crop-default ls-is-cached"
-                                                                                                            data-description="一款经典的数字华容道游戏的展示图"
-                                                                                                            width="720"
-                                                                                                            height="405"
-                                                                                                            src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/数字华容道.png">
-                                                                                                    </div>
-                                                                                                </div>
-                                                                                            </a>
-                                                                                        </div>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                    <div class="ten columns s-right-in-row s-rva-text">
-                                                                        <div class="s-item-text-group half-offset-left">
-                                                                            <div class="s-item-title">
-                                                                                <div class="s-component s-text">
-                                                                                    <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
-                                                                                        数字华容道
-                                                                                    </h3>
-                                                                                </div>
-                                                                            </div>
-                                                                            <div class="s-item-subtitle">
-                                                                                <div class="s-component s-text">
-                                                                                    <h6 class="s-component-content s-font-body">
-                                                                                        <strong>如有BUG可在下方进行反馈</strong>
-                                                                                    </h6>
-                                                                                </div>
-                                                                            </div>
-                                                                            <div class="s-item-text">
-                                                                                <div class="s-component s-text">
-                                                                                    <div class="s-component-content s-font-body">
-                                                                                        <p>
-                                                                                            <i><del>我当然知道图片中的英文翻译（可能）有问题...</del></i>
-                                                                                        </p>
-                                                                                        <p>
-                                                                                            这是一款经典的数字华容道游戏，玩家在游戏中通过<strong>移动游戏界面中相邻数字方块</strong>，<strong>使其按照1-23的顺序排列</strong>，同时<strong>左上角记录相应所用时间</strong>。感兴趣的朋友可以来挑战一下看看自己完成游戏的最短时间。
-                                                                                        </p>
-                                                                                        <p>
-                                                                                            本游戏由Duck Studio制作。<strong>手机端同样可玩！</strong>
-                                                                                        </p>
-                                                                                        <a href="https://duck-studio-2022.itch.io/digital-huarong-road/"
-                                                                                            target="_blank">点我在线游玩 (在itch.io上)</a>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                        <!-- 展示块分界 -->
-                                                        <br>
-                                                        <div data-sorting-index="0" class="s-repeatable-item">
-                                                            <div class="clearfix">
-                                                                <div>
-                                                                    <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                        <div class="s-item-media-group">
-                                                                            <div class="s-component s-media">
-                                                                                <div>
-                                                                                    <div class="s-component-content">
-                                                                                        <div class="s-img-wrapper">
+                                                    </div>
+                                                    <!-- 展示块分界 -->
+                                                    <br>
+                                                    <div data-sorting-index="5" class="s-repeatable-item s-last-row">
+                                                        <div class="clearfix">
+                                                            <div>
+                                                                <div
+                                                                    class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                    <div class="s-item-media-group">
+                                                                        <div class="s-component s-media">
+                                                                            <div>
+                                                                                <div class="s-component-content">
+                                                                                    <div class="s-img-wrapper">
+                                                                                        <a href="https://scratch.mit.edu/projects/607666265"
+                                                                                            target="_blank">
                                                                                             <div class="s-ratio-box"
-                                                                                                style="max-width: 720px; max-height: 450px;">
+                                                                                                style="max-width: 720px; max-height: 405px;">
                                                                                                 <div class="s-ratio-fill"
-                                                                                                    style="padding-bottom: 62.5%;">
+                                                                                                    style="padding-bottom: 56.25%;">
                                                                                                 </div>
-                                                                                                <div
-                                                                                                    class="s-img-wrapper">
-                                                                                                    <img alt="鸭鸭小镇"
-                                                                                                        class="crop-default"
-                                                                                                        data-description="鸭鸭小镇的展示图"
+                                                                                                <div class="s-img-wrapper">
+                                                                                                    <img alt="数字华容道的展示图"
+                                                                                                        class="crop-default ls-is-cached"
+                                                                                                        data-description="一款经典的数字华容道游戏的展示图"
                                                                                                         width="720"
-                                                                                                        height="450"
-                                                                                                        src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/鸭鸭小镇.png">
+                                                                                                        height="405"
+                                                                                                        src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/数字华容道.png">
                                                                                                 </div>
+                                                                                            </div>
+                                                                                        </a>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="ten columns s-right-in-row s-rva-text">
+                                                                    <div class="s-item-text-group half-offset-left">
+                                                                        <div class="s-item-title">
+                                                                            <div class="s-component s-text">
+                                                                                <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
+                                                                                    数字华容道
+                                                                                </h3>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="s-item-subtitle">
+                                                                            <div class="s-component s-text">
+                                                                                <h6 class="s-component-content s-font-body">
+                                                                                    <strong>如有BUG可在下方进行反馈</strong>
+                                                                                </h6>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="s-item-text">
+                                                                            <div class="s-component s-text">
+                                                                                <div class="s-component-content s-font-body">
+                                                                                    <p>
+                                                                                        <i><del>我当然知道图片中的英文翻译（可能）有问题...</del></i>
+                                                                                    </p>
+                                                                                    <p>
+                                                                                        这是一款经典的数字华容道游戏，玩家在游戏中通过<strong>移动游戏界面中相邻数字方块</strong>，<strong>使其按照1-23的顺序排列</strong>，同时<strong>左上角记录相应所用时间</strong>。感兴趣的朋友可以来挑战一下看看自己完成游戏的最短时间。
+                                                                                    </p>
+                                                                                    <p>
+                                                                                        本游戏由Duck Studio制作。<strong>手机端同样可玩！</strong>
+                                                                                    </p>
+                                                                                    <a href="https://duck-studio-2022.itch.io/digital-huarong-road/"
+                                                                                        target="_blank">点我在线游玩 (在itch.io上)</a>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <!-- 展示块分界 -->
+                                                    <br>
+                                                    <div data-sorting-index="0" class="s-repeatable-item">
+                                                        <div class="clearfix">
+                                                            <div>
+                                                                <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                    <div class="s-item-media-group">
+                                                                        <div class="s-component s-media">
+                                                                            <div>
+                                                                                <div class="s-component-content">
+                                                                                    <div class="s-img-wrapper">
+                                                                                        <div class="s-ratio-box"
+                                                                                            style="max-width: 720px; max-height: 450px;">
+                                                                                            <div class="s-ratio-fill"
+                                                                                                style="padding-bottom: 62.5%;">
+                                                                                            </div>
+                                                                                            <div class="s-img-wrapper">
+                                                                                                <img alt="鸭鸭小镇"
+                                                                                                    class="crop-default"
+                                                                                                    data-description="鸭鸭小镇的展示图"
+                                                                                                    width="720" height="450"
+                                                                                                    src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/鸭鸭小镇.png">
                                                                                             </div>
                                                                                         </div>
                                                                                     </div>
@@ -836,29 +827,29 @@ https://space.bilibili.com/2054654702/
                                                                             </div>
                                                                         </div>
                                                                     </div>
-                                                                    <div class="ten columns s-right-in-row s-rva-text">
-                                                                        <div class="s-item-text-group half-offset-left">
-                                                                            <div class="s-item-title">
-                                                                                <div class="s-component s-text">
-                                                                                    <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
-                                                                                        鸭鸭小镇
-                                                                                    </h3>
-                                                                                </div>
+                                                                </div>
+                                                                <div class="ten columns s-right-in-row s-rva-text">
+                                                                    <div class="s-item-text-group half-offset-left">
+                                                                        <div class="s-item-title">
+                                                                            <div class="s-component s-text">
+                                                                                <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
+                                                                                    鸭鸭小镇
+                                                                                </h3>
                                                                             </div>
-                                                                            <div class="s-item-subtitle">
-                                                                                <div class="s-component s-text">
-                                                                                    <h6 class="s-component-content s-font-body">
-                                                                                        <strong>来我们做的小镇地图玩玩吧~</strong>
-                                                                                    </h6>
-                                                                                </div>
+                                                                        </div>
+                                                                        <div class="s-item-subtitle">
+                                                                            <div class="s-component s-text">
+                                                                                <h6 class="s-component-content s-font-body">
+                                                                                    <strong>来我们做的小镇地图玩玩吧~</strong>
+                                                                                </h6>
                                                                             </div>
-                                                                            <div class="s-item-text">
-                                                                                <div class="s-component s-text">
-                                                                                    <div class="s-component-content s-font-body">
-                                                                                        <p>有跑酷、彩蛋、观测台等有趣的玩法，</p>
-                                                                                        <p>快来鸭鸭小镇和我们一起玩鸭~</p>
-                                                                                        <p>(Tip:<strong>我不会再对此作品进行任何更新，且他们<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/216" target="_blank">似乎将这些内容删除了</a>。</strong>)</p>
-                                                                                    </div>
+                                                                        </div>
+                                                                        <div class="s-item-text">
+                                                                            <div class="s-component s-text">
+                                                                                <div class="s-component-content s-font-body">
+                                                                                    <p>有跑酷、彩蛋、观测台等有趣的玩法，</p>
+                                                                                    <p>快来鸭鸭小镇和我们一起玩鸭~</p>
+                                                                                    <p>(Tip:<strong>我不会再对此作品进行任何更新，且他们<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/216" target="_blank">似乎将这些内容删除了</a>。</strong>)</p>
                                                                                 </div>
                                                                             </div>
                                                                         </div>
@@ -866,8 +857,8 @@ https://space.bilibili.com/2054654702/
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                        <!-- 展示块分界 -->
                                                     </div>
+                                                    <!-- 展示块分界 -->
                                                 </div>
                                             </div>
                                         </div>
@@ -880,8 +871,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -913,13 +903,11 @@ https://space.bilibili.com/2054654702/
                                                                                             <div class="s-ratio-fill"
                                                                                                 style="padding-bottom: 56.25%;">
                                                                                             </div>
-                                                                                            <div
-                                                                                                class="s-img-wrapper">
+                                                                                            <div class="s-img-wrapper">
                                                                                                 <img alt="某鸭的小站建站 3 周年贺图"
                                                                                                     class="crop-default ls-is-cached"
                                                                                                     data-description="某鸭的小站建站 3 周年贺图"
-                                                                                                    width="720"
-                                                                                                    height="405"
+                                                                                                    width="720" height="405"
                                                                                                     src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/周年庆祝/2024-3.png">
                                                                                             </div>
                                                                                         </div>
@@ -977,8 +965,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -991,28 +978,26 @@ https://space.bilibili.com/2054654702/
                                                         </div>
                                                     </div>
                                                 </div>
-                                                    <div data-sorting-index="5" class="s-repeatable-item s-last-row">
-                                                        <div class="clearfix">
-                                                            <div>
-                                                                <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                    <div class="s-item-media-group">
-                                                                        <div class="s-component s-media">
-                                                                            <div>
-                                                                                <div class="s-component-content">
-                                                                                    <div class="s-img-wrapper">
-                                                                                        <div class="s-ratio-box"
-                                                                                            style="max-width: 720px; max-height: 405px;">
-                                                                                            <div class="s-ratio-fill"
-                                                                                                style="padding-bottom: 56.25%;">
-                                                                                            </div>
-                                                                                            <div class="s-img-wrapper">
-                                                                                                <img alt="个鸭展示图"
-                                                                                                    class="crop-default ls-is-cached"
-                                                                                                    data-description="个鸭展示图"
-                                                                                                    width="720"
-                                                                                                    height="405"
-                                                                                                    src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/duck.png">
-                                                                                            </div>
+                                                <div data-sorting-index="5" class="s-repeatable-item s-last-row">
+                                                    <div class="clearfix">
+                                                        <div>
+                                                            <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                <div class="s-item-media-group">
+                                                                    <div class="s-component s-media">
+                                                                        <div>
+                                                                            <div class="s-component-content">
+                                                                                <div class="s-img-wrapper">
+                                                                                    <div class="s-ratio-box"
+                                                                                        style="max-width: 720px; max-height: 405px;">
+                                                                                        <div class="s-ratio-fill"
+                                                                                            style="padding-bottom: 56.25%;">
+                                                                                        </div>
+                                                                                        <div class="s-img-wrapper">
+                                                                                            <img alt="个鸭展示图"
+                                                                                                class="crop-default ls-is-cached"
+                                                                                                data-description="个鸭展示图"
+                                                                                                width="720" height="405"
+                                                                                                src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/duck.png">
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
@@ -1020,9 +1005,10 @@ https://space.bilibili.com/2054654702/
                                                                         </div>
                                                                     </div>
                                                                 </div>
-                                                                <div class="ten columns s-right-in-row s-rva-text">
-                                                                    <div class="s-item-text-group half-offset-left">
-                                                                        <!--  需要再用 标题和副标题
+                                                            </div>
+                                                            <div class="ten columns s-right-in-row s-rva-text">
+                                                                <div class="s-item-text-group half-offset-left">
+                                                                    <!--  需要再用 标题和副标题
                                                                         <div class="s-item-title">
                                                                             <div class="s-component s-text">
                                                                                 <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
@@ -1038,74 +1024,81 @@ https://space.bilibili.com/2054654702/
                                                                             </div>
                                                                         </div>
                                                                         -->
-                                                                        <div class="s-item-text">
-                                                                            <div class="s-component s-text">
-                                                                                <div class="s-component-content s-font-body">
-                                                                                    <p><a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/chinese_git/" target="_blank">中文Git</a>&nbsp;|&nbsp;<a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/" target="_blank">芙芙工具箱</a>&nbsp;|&nbsp;<a href="https://github.com/DuckDuckStudio/GenshinImpact-UP-Search" target="_blank">GUS</a>(GenshinImpact UP Search)&nbsp;|&nbsp;<a href="https://github.com/DuckDuckStudio/GitHub-Labels-Manager" target="_blank">GLM</a>(GitHub Labels Manager)<br>的作者</p>
-                                                                                    <p>GitHub Star: <strong><span id="total-stars">[计算中...]</span></strong></p>
-                                                                                    <p>不会聊天...(万能的关键字)</p>
-                                                                                    <p><del>整天在网页里写本地路径</del></p>
-                                                                                    <script>
-                                                                                        /* 
-                                                                                        * JS输出分类: 位置
-                                                                                        */
-                                                                                        fetch('https://ipapi.co/json/')
-                                                                                            .then(response => response.json())
-                                                                                            .then(data => {
-                                                                                                const city = data.city; // 城市 Zhangzhou
-                                                                                                const province = data.region; // 省份 Fujian
-                                                                                                const country = data.country_code; // 国家代码 CN
+                                                                    <div class="s-item-text">
+                                                                        <div class="s-component s-text">
+                                                                            <div class="s-component-content s-font-body">
+                                                                                <p>
+                                                                                    <a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/chinese_git/" target="_blank">中文Git</a>
+                                                                                    &nbsp;|&nbsp;
+                                                                                    <a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/" target="_blank">芙芙工具箱</a>
+                                                                                    &nbsp;|&nbsp;
+                                                                                    <a href="https://github.com/DuckDuckStudio/GitHub-Labels-Manager" target="_blank">GLM</a>(GitHub Labels Manager)
+                                                                                </p>
+                                                                                <p>的作者</p>
+                                                                                <p>GitHub Star: <strong><span id="total-stars">[计算中...]</span></strong></p>
+                                                                                <p>不会聊天...(万能的关键字)</p>
+                                                                                <p><del>整天在网页里写本地路径</del></p>
+                                                                                <script>
+                                                                                    /* 
+                                                                                    * JS输出分类: 位置
+                                                                                    */
+                                                                                    fetch('https://ipapi.co/json/')
+                                                                                        .then(response => response.json())
+                                                                                        .then(data => {
+                                                                                            const city = data.city; // 城市 Zhangzhou
+                                                                                            const province = data.region; // 省份 Fujian
+                                                                                            const country = data.country_code; // 国家代码 CN
 
-                                                                                                const cityMessages = {
-                                                                                                    'CN': {
-                                                                                                        'Fujian': '福建',
-                                                                                                        'Guangdong': '广东',
-                                                                                                        'HeBei': '河北',
-                                                                                                        // 四个直辖市
-                                                                                                        'Beijing': '北京',
-                                                                                                        'Shanghai': '上海',
-                                                                                                        'Tianjin': '天津',
-                                                                                                        'Chongqing': '重庆',
-                                                                                                    },
-                                                                                                };
+                                                                                            const cityMessages = {
+                                                                                                'CN': {
+                                                                                                    'Fujian': '福建',
+                                                                                                    'Guangdong': '广东',
+                                                                                                    'HeBei': '河北',
+                                                                                                    // 四个直辖市
+                                                                                                    'Beijing': '北京',
+                                                                                                    'Shanghai': '上海',
+                                                                                                    'Tianjin': '天津',
+                                                                                                    'Chongqing': '重庆',
+                                                                                                },
+                                                                                            };
 
-                                                                                                let welcomeMessage = '';
+                                                                                            let welcomeMessage = '';
 
-                                                                                                if (country === 'CN') {
-                                                                                                    if (cityMessages[country] && cityMessages[country][province]) {
-                                                                                                        welcomeMessage = `你好，${cityMessages[country][province]}！`;
-                                                                                                    } else {
-                                                                                                        console.warn("[WARN(位置-映射)] 你所在的地区没有被映射，请提交Issue或PR补充，记得带上控制台输出[TEST(位置)]")
-                                                                                                        welcomeMessage = `你好，${province}！`;
-                                                                                                    }
-                                                                                                } else if (country === 'JP') {
-                                                                                                    welcomeMessage = `こんにちは、${province}！`;
+                                                                                            if (country === 'CN') {
+                                                                                                if (cityMessages[country] && cityMessages[country][province]) {
+                                                                                                    welcomeMessage = `你好，${cityMessages[country][province]}！`;
                                                                                                 } else {
-                                                                                                    welcomeMessage = `Hello, ${province}!`;
+                                                                                                    console.warn("[WARN(位置-映射)] 你所在的地区没有被映射，请提交Issue或PR补充，记得带上控制台输出[TEST(位置)]")
+                                                                                                    welcomeMessage = `你好，${province}！`;
                                                                                                 }
+                                                                                            } else if (country === 'JP') {
+                                                                                                welcomeMessage = `こんにちは、${province}！`;
+                                                                                            } else {
+                                                                                                welcomeMessage = `Hello, ${province}!`;
+                                                                                            }
 
-                                                                                                console.debug(`%c[TEST(位置)] ${country} | ${province} | ${city}`, 'color: cyan;');
+                                                                                            console.debug(`%c[TEST(位置)] ${country} | ${province} | ${city}`, 'color: cyan;');
 
-                                                                                                const helloSpan = document.getElementById('hello-there');
-                                                                                                helloSpan.textContent = welcomeMessage;
-                                                                                            })
+                                                                                            const helloSpan = document.getElementById('hello-there');
+                                                                                            helloSpan.textContent = welcomeMessage;
+                                                                                        })
                                                                                         .catch(error => console.error('[ERROR(位置)]获取地区失败:', error));
 
-                                                                                        // ------- 位置 ↑ --- GitHub 状态 ↓ -------
+                                                                                    // ------- 位置 ↑ --- GitHub 状态 ↓ -------
 
-                                                                                        /* 
-                                                                                        * JS输出分类: GitHub状态
-                                                                                        */
+                                                                                    /* 
+                                                                                    * JS输出分类: GitHub状态
+                                                                                    */
 
-                                                                                        const USERNAME = 'DuckDuckStudio';
+                                                                                    const USERNAME = 'DuckDuckStudio';
 
-                                                                                        async function getTotalStars() {
-                                                                                            try {
-                                                                                                let totalStars = 0;
-                                                                                                let page = 1;
-                                                                                                let hasMoreRepos = true;
+                                                                                    async function getTotalStars() {
+                                                                                        try {
+                                                                                            let totalStars = 0;
+                                                                                            let page = 1;
+                                                                                            let hasMoreRepos = true;
 
-                                                                                                while (hasMoreRepos) {
+                                                                                            while (hasMoreRepos) {
                                                                                                 const response = await fetch(`https://api.github.com/users/${USERNAME}/repos?per_page=100&page=${page}`);
 
                                                                                                 if (!response.ok) {
@@ -1117,23 +1110,22 @@ https://space.bilibili.com/2054654702/
                                                                                                     hasMoreRepos = false;
                                                                                                 } else {
                                                                                                     for (const repo of repos) {
-                                                                                                    totalStars += repo.stargazers_count;
+                                                                                                        totalStars += repo.stargazers_count;
                                                                                                     }
                                                                                                     page++;
                                                                                                 }
-                                                                                                }
-
-                                                                                                //console.log(`一共获取到: ${totalStars} ⭐`);
-                                                                                                document.getElementById('total-stars').innerText = `${totalStars} ⭐`;
-                                                                                            } catch (error) {
-                                                                                                console.error('[ERROR(GitHub状态-替换)] GitHub Star 自动替换出错:', error);
-                                                                                                document.getElementById('total-stars').innerText = `❌ 数据获取出错，参阅输出以获取更多信息`;
                                                                                             }
-                                                                                        }
 
-                                                                                        getTotalStars();
-                                                                                    </script>
-                                                                                </div>
+                                                                                            //console.log(`一共获取到: ${totalStars} ⭐`);
+                                                                                            document.getElementById('total-stars').innerText = `${totalStars} ⭐`;
+                                                                                        } catch (error) {
+                                                                                            console.error('[ERROR(GitHub状态-替换)] GitHub Star 自动替换出错:', error);
+                                                                                            document.getElementById('total-stars').innerText = `❌ 数据获取出错，参阅输出以获取更多信息`;
+                                                                                        }
+                                                                                    }
+
+                                                                                    getTotalStars();
+                                                                                </script>
                                                                             </div>
                                                                         </div>
                                                                     </div>
@@ -1141,9 +1133,9 @@ https://space.bilibili.com/2054654702/
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <!-- 展示块分界 -->
-                                                    <br>
                                                 </div>
+                                                <!-- 展示块分界 -->
+                                                <br>
                                             </div>
                                         </div>
                                     </div>
@@ -1176,7 +1168,7 @@ https://space.bilibili.com/2054654702/
                                                 <p>©Duck studio 2021 - <span id="now_year">2024</span></p>
                                                 <script>
                                                     /* 周年庆祝文本显示(自动修改&显示) */
-                                                    window.onload = function() {
+                                                    window.onload = function () {
                                                         var Now = new Date();
                                                         var currentYear = Now.getFullYear(); // 获取当前年份
                                                         var startTimeString = currentYear + "-05-14T15:16:17+08:00";
@@ -1241,7 +1233,7 @@ https://space.bilibili.com/2054654702/
                                                             const formattedDateTime = `${year}年${month}月${day}日 ${hours}时${minutes}分`;
 
                                                             // 替换 #123 为链接
-                                                            latestCommitMessage = latestCommitMessage.replace(/#(\d+)/g, function(match, issueNumber) {
+                                                            latestCommitMessage = latestCommitMessage.replace(/#(\d+)/g, function (match, issueNumber) {
                                                                 return `<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/${issueNumber}" target="_blank">${match}</a>`;
                                                             });
 
@@ -1266,7 +1258,7 @@ https://space.bilibili.com/2054654702/
                                                     style="font-size: 17px; letter-spacing: 0px;">
                                                     <b>标题</b>
                                                 </p>-->
-                                                <img src="https://duckduckstudio.github.io/yazicbs.github.io/font/做根号的自己.png" width="100%" height="100%" alt="做更好的自己">
+                                                <img src="https://duckduckstudio.github.io/yazicbs.github.io/font/做根号的自己.png" style="width: 100%; height: 100%;" alt="做更好的自己">
                                             </div>
                                         </div>
                                     </div>

--- a/zh_cn/index.html
+++ b/zh_cn/index.html
@@ -49,8 +49,6 @@ ddddd    u u u  c c c  k   k     sssss  t   u u u   ddddd  i   oooo
         <!-- 定义网站的名称 -->
         <meta content="鸭鸭工作室的官方网站" property="og:description">
         <!-- 定义网页的描述，用于社交媒体分享时显示 -->
-        <meta content="鸭鸭工作室 | 鸭鸭「カモ」" itemprop="name">
-        <!-- 来自ChatGPT: itemprop 属性提供了与 og:title、og:description 和 og:image 相同的信息，用于标记页面上的结构化数据 -->
         <meta name="description" content="[鸭鸭工作室 | 鸭鸭「カモ」] 这是鸭鸭工作室(Duck Studio)的官方网站，你可以在这个网站上找到关于我的一些作品。">
         <!-- 优化对于bing的结果描述 -->
         <meta content="鸭鸭工作室,鸭鸭「カモ」,DuckStudio,Yzcbs,鸭子出版社" name="keywords">
@@ -105,7 +103,6 @@ https://space.bilibili.com/2054654702/
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.css">
         <div id="aplayer"></div>
         <script src="https://cdn.jsdelivr.net/npm/aplayer/dist/APlayer.min.js"></script>
-        
         <script src="https://duckduckstudio.github.io/yazicbs.github.io/zh_cn/js/SongList.js"></script>
         <!-- END -->
         <div>
@@ -114,7 +111,6 @@ https://space.bilibili.com/2054654702/
                     <div class="css-2ezjh4 css-1mzqwyc0">
                         <div class="page-wrapper">
                             <ul class="slides s-page-1 " style="display: block; list-style-type: none;">
-                            <!-- 此处Visual Studio提示[元素"ul"需要结束标记]，但在第 1054 行已有结束标记。故忽略该警告。 -->
                                 <li class="slide s-section-1 s-first-visible-section css-3757m5">
                                     <div class="waypoint"></div>
                                     <a class="section-anchor"></a>
@@ -208,7 +204,7 @@ https://space.bilibili.com/2054654702/
                                                                         let typing = true;
 
                                                                         // 设置定时器，每200毫秒执行一次
-                                                                        setInterval(function() {
+                                                                        setInterval(function () {
                                                                             if (typing) {
                                                                                 // 正在打字状态，显示当前字符串的前charIndex个字符
                                                                                 text.innerHTML = currentOrder[currentIndex].slice(0, ++charIndex);
@@ -220,7 +216,7 @@ https://space.bilibili.com/2054654702/
                                                                             // 判断打字或删除字是否完成
                                                                             if (charIndex === currentOrder[currentIndex].length + 3) {
                                                                                 // 打字完成后停留时间较长（1000毫秒），然后切换到删除字状态
-                                                                                setTimeout(function() {
+                                                                                setTimeout(function () {
                                                                                     typing = false;
                                                                                 }, 1000);
                                                                             } else if (charIndex < 0) {
@@ -299,8 +295,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -711,10 +706,9 @@ https://space.bilibili.com/2054654702/
                                                                                             <strong>目前仅支持电脑端。</strong>
                                                                                         </p>
                                                                                         <p>
-                                                                                        <a href="https://duckduckstudio.github.io/yazicbs.github.io/Duck%20Parkour.html"
-                                                                                            target="_blank">在线试玩</a>
-                                                                                            </p>
-                                                                                        </div>
+                                                                                            <a href="https://duckduckstudio.github.io/yazicbs.github.io/Duck%20Parkour.html"
+                                                                                                target="_blank">在线试玩</a>
+                                                                                        </p>
                                                                                     </div>
                                                                                 </div>
                                                                             </div>
@@ -723,105 +717,102 @@ https://space.bilibili.com/2054654702/
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                        <!-- 展示块分界 -->
-                                                        <br>
-                                                        <div data-sorting-index="5" class="s-repeatable-item s-last-row">
-                                                            <div class="clearfix">
-                                                                <div>
-                                                                    <div
-                                                                        class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                        <div class="s-item-media-group">
-                                                                            <div class="s-component s-media">
-                                                                                <div>
-                                                                                    <div class="s-component-content">
-                                                                                        <div class="s-img-wrapper">
-                                                                                            <a href="https://scratch.mit.edu/projects/607666265"
-                                                                                                target="_blank">
-                                                                                                <div class="s-ratio-box"
-                                                                                                    style="max-width: 720px; max-height: 405px;">
-                                                                                                    <div class="s-ratio-fill"
-                                                                                                        style="padding-bottom: 56.25%;">
-                                                                                                    </div>
-                                                                                                    <div
-                                                                                                        class="s-img-wrapper">
-                                                                                                        <img alt="数字华容道的展示图"
-                                                                                                            class="crop-default ls-is-cached"
-                                                                                                            data-description="一款经典的数字华容道游戏的展示图"
-                                                                                                            width="720"
-                                                                                                            height="405"
-                                                                                                            src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/数字华容道.png">
-                                                                                                    </div>
-                                                                                                </div>
-                                                                                            </a>
-                                                                                        </div>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                    <div class="ten columns s-right-in-row s-rva-text">
-                                                                        <div class="s-item-text-group half-offset-left">
-                                                                            <div class="s-item-title">
-                                                                                <div class="s-component s-text">
-                                                                                    <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
-                                                                                        数字华容道
-                                                                                    </h3>
-                                                                                </div>
-                                                                            </div>
-                                                                            <div class="s-item-subtitle">
-                                                                                <div class="s-component s-text">
-                                                                                    <h6 class="s-component-content s-font-body">
-                                                                                        <strong>如有BUG可在下方进行反馈</strong>
-                                                                                    </h6>
-                                                                                </div>
-                                                                            </div>
-                                                                            <div class="s-item-text">
-                                                                                <div class="s-component s-text">
-                                                                                    <div class="s-component-content s-font-body">
-                                                                                        <p>
-                                                                                            <i><del>我当然知道图片中的英文翻译（可能）有问题...</del></i>
-                                                                                        </p>
-                                                                                        <p>
-                                                                                            这是一款经典的数字华容道游戏，玩家在游戏中通过<strong>移动游戏界面中相邻数字方块</strong>，<strong>使其按照1-23的顺序排列</strong>，同时<strong>左上角记录相应所用时间</strong>。感兴趣的朋友可以来挑战一下看看自己完成游戏的最短时间。
-                                                                                        </p>
-                                                                                        <p>
-                                                                                            本游戏由Duck Studio制作。<strong>手机端同样可玩！</strong>
-                                                                                        </p>
-                                                                                        <a href="https://duck-studio-2022.itch.io/digital-huarong-road/"
-                                                                                            target="_blank">点我在线游玩 (在itch.io上)</a>
-                                                                                    </div>
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                        <!-- 展示块分界 -->
-                                                        <br>
-                                                        <div data-sorting-index="0" class="s-repeatable-item">
-                                                            <div class="clearfix">
-                                                                <div>
-                                                                    <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                        <div class="s-item-media-group">
-                                                                            <div class="s-component s-media">
-                                                                                <div>
-                                                                                    <div class="s-component-content">
-                                                                                        <div class="s-img-wrapper">
+                                                    </div>
+                                                    <!-- 展示块分界 -->
+                                                    <br>
+                                                    <div data-sorting-index="5" class="s-repeatable-item s-last-row">
+                                                        <div class="clearfix">
+                                                            <div>
+                                                                <div
+                                                                    class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                    <div class="s-item-media-group">
+                                                                        <div class="s-component s-media">
+                                                                            <div>
+                                                                                <div class="s-component-content">
+                                                                                    <div class="s-img-wrapper">
+                                                                                        <a href="https://scratch.mit.edu/projects/607666265"
+                                                                                            target="_blank">
                                                                                             <div class="s-ratio-box"
-                                                                                                style="max-width: 720px; max-height: 450px;">
+                                                                                                style="max-width: 720px; max-height: 405px;">
                                                                                                 <div class="s-ratio-fill"
-                                                                                                    style="padding-bottom: 62.5%;">
+                                                                                                    style="padding-bottom: 56.25%;">
                                                                                                 </div>
-                                                                                                <div
-                                                                                                    class="s-img-wrapper">
-                                                                                                    <img alt="鸭鸭小镇"
-                                                                                                        class="crop-default"
-                                                                                                        data-description="鸭鸭小镇的展示图"
+                                                                                                <div class="s-img-wrapper">
+                                                                                                    <img alt="数字华容道的展示图"
+                                                                                                        class="crop-default ls-is-cached"
+                                                                                                        data-description="一款经典的数字华容道游戏的展示图"
                                                                                                         width="720"
-                                                                                                        height="450"
-                                                                                                        src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/鸭鸭小镇.png">
+                                                                                                        height="405"
+                                                                                                        src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/数字华容道.png">
                                                                                                 </div>
+                                                                                            </div>
+                                                                                        </a>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                <div class="ten columns s-right-in-row s-rva-text">
+                                                                    <div class="s-item-text-group half-offset-left">
+                                                                        <div class="s-item-title">
+                                                                            <div class="s-component s-text">
+                                                                                <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
+                                                                                    数字华容道
+                                                                                </h3>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="s-item-subtitle">
+                                                                            <div class="s-component s-text">
+                                                                                <h6 class="s-component-content s-font-body">
+                                                                                    <strong>如有BUG可在下方进行反馈</strong>
+                                                                                </h6>
+                                                                            </div>
+                                                                        </div>
+                                                                        <div class="s-item-text">
+                                                                            <div class="s-component s-text">
+                                                                                <div class="s-component-content s-font-body">
+                                                                                    <p>
+                                                                                        <i><del>我当然知道图片中的英文翻译（可能）有问题...</del></i>
+                                                                                    </p>
+                                                                                    <p>
+                                                                                        这是一款经典的数字华容道游戏，玩家在游戏中通过<strong>移动游戏界面中相邻数字方块</strong>，<strong>使其按照1-23的顺序排列</strong>，同时<strong>左上角记录相应所用时间</strong>。感兴趣的朋友可以来挑战一下看看自己完成游戏的最短时间。
+                                                                                    </p>
+                                                                                    <p>
+                                                                                        本游戏由Duck Studio制作。<strong>手机端同样可玩！</strong>
+                                                                                    </p>
+                                                                                    <a href="https://duck-studio-2022.itch.io/digital-huarong-road/"
+                                                                                        target="_blank">点我在线游玩 (在itch.io上)</a>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <!-- 展示块分界 -->
+                                                    <br>
+                                                    <div data-sorting-index="0" class="s-repeatable-item">
+                                                        <div class="clearfix">
+                                                            <div>
+                                                                <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                    <div class="s-item-media-group">
+                                                                        <div class="s-component s-media">
+                                                                            <div>
+                                                                                <div class="s-component-content">
+                                                                                    <div class="s-img-wrapper">
+                                                                                        <div class="s-ratio-box"
+                                                                                            style="max-width: 720px; max-height: 450px;">
+                                                                                            <div class="s-ratio-fill"
+                                                                                                style="padding-bottom: 62.5%;">
+                                                                                            </div>
+                                                                                            <div class="s-img-wrapper">
+                                                                                                <img alt="鸭鸭小镇"
+                                                                                                    class="crop-default"
+                                                                                                    data-description="鸭鸭小镇的展示图"
+                                                                                                    width="720" height="450"
+                                                                                                    src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/鸭鸭小镇.png">
                                                                                             </div>
                                                                                         </div>
                                                                                     </div>
@@ -829,29 +820,29 @@ https://space.bilibili.com/2054654702/
                                                                             </div>
                                                                         </div>
                                                                     </div>
-                                                                    <div class="ten columns s-right-in-row s-rva-text">
-                                                                        <div class="s-item-text-group half-offset-left">
-                                                                            <div class="s-item-title">
-                                                                                <div class="s-component s-text">
-                                                                                    <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
-                                                                                        鸭鸭小镇
-                                                                                    </h3>
-                                                                                </div>
+                                                                </div>
+                                                                <div class="ten columns s-right-in-row s-rva-text">
+                                                                    <div class="s-item-text-group half-offset-left">
+                                                                        <div class="s-item-title">
+                                                                            <div class="s-component s-text">
+                                                                                <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
+                                                                                    鸭鸭小镇
+                                                                                </h3>
                                                                             </div>
-                                                                            <div class="s-item-subtitle">
-                                                                                <div class="s-component s-text">
-                                                                                    <h6 class="s-component-content s-font-body">
-                                                                                        <strong>来我们做的小镇地图玩玩吧~</strong>
-                                                                                    </h6>
-                                                                                </div>
+                                                                        </div>
+                                                                        <div class="s-item-subtitle">
+                                                                            <div class="s-component s-text">
+                                                                                <h6 class="s-component-content s-font-body">
+                                                                                    <strong>来我们做的小镇地图玩玩吧~</strong>
+                                                                                </h6>
                                                                             </div>
-                                                                            <div class="s-item-text">
-                                                                                <div class="s-component s-text">
-                                                                                    <div class="s-component-content s-font-body">
-                                                                                        <p>有跑酷、彩蛋、观测台等有趣的玩法，</p>
-                                                                                        <p>快来鸭鸭小镇和我们一起玩鸭~</p>
-                                                                                        <p>(Tip:<strong>我不会再对此作品进行任何更新，且他们<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/216" target="_blank">似乎将这些内容删除了</a>。</strong>)</p>
-                                                                                    </div>
+                                                                        </div>
+                                                                        <div class="s-item-text">
+                                                                            <div class="s-component s-text">
+                                                                                <div class="s-component-content s-font-body">
+                                                                                    <p>有跑酷、彩蛋、观测台等有趣的玩法，</p>
+                                                                                    <p>快来鸭鸭小镇和我们一起玩鸭~</p>
+                                                                                    <p>(Tip:<strong>我不会再对此作品进行任何更新，且他们<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/216" target="_blank">似乎将这些内容删除了</a>。</strong>)</p>
                                                                                 </div>
                                                                             </div>
                                                                         </div>
@@ -859,8 +850,8 @@ https://space.bilibili.com/2054654702/
                                                                 </div>
                                                             </div>
                                                         </div>
-                                                        <!-- 展示块分界 -->
                                                     </div>
+                                                    <!-- 展示块分界 -->
                                                 </div>
                                             </div>
                                         </div>
@@ -873,8 +864,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -906,13 +896,11 @@ https://space.bilibili.com/2054654702/
                                                                                             <div class="s-ratio-fill"
                                                                                                 style="padding-bottom: 56.25%;">
                                                                                             </div>
-                                                                                            <div
-                                                                                                class="s-img-wrapper">
+                                                                                            <div class="s-img-wrapper">
                                                                                                 <img alt="某鸭的小站建站 3 周年贺图"
                                                                                                     class="crop-default ls-is-cached"
                                                                                                     data-description="某鸭的小站建站 3 周年贺图"
-                                                                                                    width="720"
-                                                                                                    height="405"
+                                                                                                    width="720" height="405"
                                                                                                     src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/周年庆祝/2024-3.png">
                                                                                             </div>
                                                                                         </div>
@@ -970,8 +958,7 @@ https://space.bilibili.com/2054654702/
                                     <a class="section-anchor"></a>
                                     <div>
                                         <div class="transition collapse-bottom-padding s-new-media-section s-section s-rows-section background-image"
-                                            data-react-style="{}"
-                                            style="text-align: left;">
+                                            data-react-style="{}" style="text-align: left;">
                                             <div class="container">
                                                 <div class="columns sixteen">
                                                     <div class="s-title-group">
@@ -984,28 +971,26 @@ https://space.bilibili.com/2054654702/
                                                         </div>
                                                     </div>
                                                 </div>
-                                                    <div data-sorting-index="5" class="s-repeatable-item s-last-row">
-                                                        <div class="clearfix">
-                                                            <div>
-                                                                <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
-                                                                    <div class="s-item-media-group">
-                                                                        <div class="s-component s-media">
-                                                                            <div>
-                                                                                <div class="s-component-content">
-                                                                                    <div class="s-img-wrapper">
-                                                                                        <div class="s-ratio-box"
-                                                                                            style="max-width: 720px; max-height: 405px;">
-                                                                                            <div class="s-ratio-fill"
-                                                                                                style="padding-bottom: 56.25%;">
-                                                                                            </div>
-                                                                                            <div class="s-img-wrapper">
-                                                                                                <img alt="个鸭展示图"
-                                                                                                    class="crop-default ls-is-cached"
-                                                                                                    data-description="个鸭展示图"
-                                                                                                    width="720"
-                                                                                                    height="405"
-                                                                                                    src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/duck.png">
-                                                                                            </div>
+                                                <div data-sorting-index="5" class="s-repeatable-item s-last-row">
+                                                    <div class="clearfix">
+                                                        <div>
+                                                            <div class="s-item-media-wrapper six columns  s-left-in-row s-rva-media">
+                                                                <div class="s-item-media-group">
+                                                                    <div class="s-component s-media">
+                                                                        <div>
+                                                                            <div class="s-component-content">
+                                                                                <div class="s-img-wrapper">
+                                                                                    <div class="s-ratio-box"
+                                                                                        style="max-width: 720px; max-height: 405px;">
+                                                                                        <div class="s-ratio-fill"
+                                                                                            style="padding-bottom: 56.25%;">
+                                                                                        </div>
+                                                                                        <div class="s-img-wrapper">
+                                                                                            <img alt="个鸭展示图"
+                                                                                                class="crop-default ls-is-cached"
+                                                                                                data-description="个鸭展示图"
+                                                                                                width="720" height="405"
+                                                                                                src="https://duckduckstudio.github.io/yazicbs.github.io/pictures/duck.png">
                                                                                         </div>
                                                                                     </div>
                                                                                 </div>
@@ -1013,9 +998,10 @@ https://space.bilibili.com/2054654702/
                                                                         </div>
                                                                     </div>
                                                                 </div>
-                                                                <div class="ten columns s-right-in-row s-rva-text">
-                                                                    <div class="s-item-text-group half-offset-left">
-                                                                        <!--  需要再用 标题和副标题
+                                                            </div>
+                                                            <div class="ten columns s-right-in-row s-rva-text">
+                                                                <div class="s-item-text-group half-offset-left">
+                                                                    <!--  需要再用 标题和副标题
                                                                         <div class="s-item-title">
                                                                             <div class="s-component s-text">
                                                                                 <h3 class="s-component-content s-font-heading" style="font-size: 130%;">
@@ -1031,74 +1017,81 @@ https://space.bilibili.com/2054654702/
                                                                             </div>
                                                                         </div>
                                                                         -->
-                                                                        <div class="s-item-text">
-                                                                            <div class="s-component s-text">
-                                                                                <div class="s-component-content s-font-body">
-                                                                                    <p><a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/chinese_git/" target="_blank">中文Git</a>&nbsp;|&nbsp;<a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/" target="_blank">芙芙工具箱</a>&nbsp;|&nbsp;<a href="https://github.com/DuckDuckStudio/GenshinImpact-UP-Search" target="_blank">GUS</a>(GenshinImpact UP Search)&nbsp;|&nbsp;<a href="https://github.com/DuckDuckStudio/GitHub-Labels-Manager" target="_blank">GLM</a>(GitHub Labels Manager)<br>的作者</p>
-                                                                                    <p>GitHub Star: <strong><span id="total-stars">[计算中...]</span></strong></p>
-                                                                                    <p>不会聊天...(万能的关键字)</p>
-                                                                                    <p><del>整天在网页里写本地路径</del></p>
-                                                                                    <script>
-                                                                                        /* 
-                                                                                        * JS输出分类: 位置
-                                                                                        */
-                                                                                        fetch('https://ipapi.co/json/')
-                                                                                            .then(response => response.json())
-                                                                                            .then(data => {
-                                                                                                const city = data.city; // 城市 Zhangzhou
-                                                                                                const province = data.region; // 省份 Fujian
-                                                                                                const country = data.country_code; // 国家代码 CN
+                                                                    <div class="s-item-text">
+                                                                        <div class="s-component s-text">
+                                                                            <div class="s-component-content s-font-body">
+                                                                                <p>
+                                                                                    <a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/chinese_git/" target="_blank">中文Git</a>
+                                                                                    &nbsp;|&nbsp;
+                                                                                    <a href="https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/" target="_blank">芙芙工具箱</a>
+                                                                                    &nbsp;|&nbsp;
+                                                                                    <a href="https://github.com/DuckDuckStudio/GitHub-Labels-Manager" target="_blank">GLM</a>(GitHub Labels Manager)
+                                                                                </p>
+                                                                                <p>的作者</p>
+                                                                                <p>GitHub Star: <strong><span id="total-stars">[计算中...]</span></strong></p>
+                                                                                <p>不会聊天...(万能的关键字)</p>
+                                                                                <p><del>整天在网页里写本地路径</del></p>
+                                                                                <script>
+                                                                                    /* 
+                                                                                    * JS输出分类: 位置
+                                                                                    */
+                                                                                    fetch('https://ipapi.co/json/')
+                                                                                        .then(response => response.json())
+                                                                                        .then(data => {
+                                                                                            const city = data.city; // 城市 Zhangzhou
+                                                                                            const province = data.region; // 省份 Fujian
+                                                                                            const country = data.country_code; // 国家代码 CN
 
-                                                                                                const cityMessages = {
-                                                                                                    'CN': {
-                                                                                                        'Fujian': '福建',
-                                                                                                        'Guangdong': '广东',
-                                                                                                        'HeBei': '河北',
-                                                                                                        // 四个直辖市
-                                                                                                        'Beijing': '北京',
-                                                                                                        'Shanghai': '上海',
-                                                                                                        'Tianjin': '天津',
-                                                                                                        'Chongqing': '重庆',
-                                                                                                    },
-                                                                                                };
+                                                                                            const cityMessages = {
+                                                                                                'CN': {
+                                                                                                    'Fujian': '福建',
+                                                                                                    'Guangdong': '广东',
+                                                                                                    'HeBei': '河北',
+                                                                                                    // 四个直辖市
+                                                                                                    'Beijing': '北京',
+                                                                                                    'Shanghai': '上海',
+                                                                                                    'Tianjin': '天津',
+                                                                                                    'Chongqing': '重庆',
+                                                                                                },
+                                                                                            };
 
-                                                                                                let welcomeMessage = '';
+                                                                                            let welcomeMessage = '';
 
-                                                                                                if (country === 'CN') {
-                                                                                                    if (cityMessages[country] && cityMessages[country][province]) {
-                                                                                                        welcomeMessage = `你好，${cityMessages[country][province]}！`;
-                                                                                                    } else {
-                                                                                                        console.warn("[WARN(位置-映射)] 你所在的地区没有被映射，请提交Issue或PR补充，记得带上控制台输出[TEST(位置)]")
-                                                                                                        welcomeMessage = `你好，${province}！`;
-                                                                                                    }
-                                                                                                } else if (country === 'JP') {
-                                                                                                    welcomeMessage = `こんにちは、${province}！`;
+                                                                                            if (country === 'CN') {
+                                                                                                if (cityMessages[country] && cityMessages[country][province]) {
+                                                                                                    welcomeMessage = `你好，${cityMessages[country][province]}！`;
                                                                                                 } else {
-                                                                                                    welcomeMessage = `Hello, ${province}!`;
+                                                                                                    console.warn("[WARN(位置-映射)] 你所在的地区没有被映射，请提交Issue或PR补充，记得带上控制台输出[TEST(位置)]")
+                                                                                                    welcomeMessage = `你好，${province}！`;
                                                                                                 }
+                                                                                            } else if (country === 'JP') {
+                                                                                                welcomeMessage = `こんにちは、${province}！`;
+                                                                                            } else {
+                                                                                                welcomeMessage = `Hello, ${province}!`;
+                                                                                            }
 
-                                                                                                console.debug(`%c[TEST(位置)] ${country} | ${province} | ${city}`, 'color: cyan;');
+                                                                                            console.debug(`%c[TEST(位置)] ${country} | ${province} | ${city}`, 'color: cyan;');
 
-                                                                                                const helloSpan = document.getElementById('hello-there');
-                                                                                                helloSpan.textContent = welcomeMessage;
-                                                                                            })
+                                                                                            const helloSpan = document.getElementById('hello-there');
+                                                                                            helloSpan.textContent = welcomeMessage;
+                                                                                        })
                                                                                         .catch(error => console.error('[ERROR(位置)]获取地区失败:', error));
 
-                                                                                        // ------- 位置 ↑ --- GitHub 状态 ↓ -------
+                                                                                    // ------- 位置 ↑ --- GitHub 状态 ↓ -------
 
-                                                                                        /* 
-                                                                                        * JS输出分类: GitHub状态
-                                                                                        */
+                                                                                    /* 
+                                                                                    * JS输出分类: GitHub状态
+                                                                                    */
 
-                                                                                        const USERNAME = 'DuckDuckStudio';
+                                                                                    const USERNAME = 'DuckDuckStudio';
 
-                                                                                        async function getTotalStars() {
-                                                                                            try {
-                                                                                                let totalStars = 0;
-                                                                                                let page = 1;
-                                                                                                let hasMoreRepos = true;
+                                                                                    async function getTotalStars() {
+                                                                                        try {
+                                                                                            let totalStars = 0;
+                                                                                            let page = 1;
+                                                                                            let hasMoreRepos = true;
 
-                                                                                                while (hasMoreRepos) {
+                                                                                            while (hasMoreRepos) {
                                                                                                 const response = await fetch(`https://api.github.com/users/${USERNAME}/repos?per_page=100&page=${page}`);
 
                                                                                                 if (!response.ok) {
@@ -1110,23 +1103,22 @@ https://space.bilibili.com/2054654702/
                                                                                                     hasMoreRepos = false;
                                                                                                 } else {
                                                                                                     for (const repo of repos) {
-                                                                                                    totalStars += repo.stargazers_count;
+                                                                                                        totalStars += repo.stargazers_count;
                                                                                                     }
                                                                                                     page++;
                                                                                                 }
-                                                                                                }
-
-                                                                                                //console.log(`一共获取到: ${totalStars} ⭐`);
-                                                                                                document.getElementById('total-stars').innerText = `${totalStars} ⭐`;
-                                                                                            } catch (error) {
-                                                                                                console.error('[ERROR(GitHub状态-替换)] GitHub Star 自动替换出错:', error);
-                                                                                                document.getElementById('total-stars').innerText = `❌ 数据获取出错，参阅输出以获取更多信息`;
                                                                                             }
-                                                                                        }
 
-                                                                                        getTotalStars();
-                                                                                    </script>
-                                                                                </div>
+                                                                                            //console.log(`一共获取到: ${totalStars} ⭐`);
+                                                                                            document.getElementById('total-stars').innerText = `${totalStars} ⭐`;
+                                                                                        } catch (error) {
+                                                                                            console.error('[ERROR(GitHub状态-替换)] GitHub Star 自动替换出错:', error);
+                                                                                            document.getElementById('total-stars').innerText = `❌ 数据获取出错，参阅输出以获取更多信息`;
+                                                                                        }
+                                                                                    }
+
+                                                                                    getTotalStars();
+                                                                                </script>
                                                                             </div>
                                                                         </div>
                                                                     </div>
@@ -1134,9 +1126,9 @@ https://space.bilibili.com/2054654702/
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <!-- 展示块分界 -->
-                                                    <br>
                                                 </div>
+                                                <!-- 展示块分界 -->
+                                                <br>
                                             </div>
                                         </div>
                                     </div>
@@ -1169,7 +1161,7 @@ https://space.bilibili.com/2054654702/
                                                 <p>©Duck studio 2021 - <span id="now_year">2024</span></p>
                                                 <script>
                                                     /* 周年庆祝文本显示(自动修改&显示) */
-                                                    window.onload = function() {
+                                                    window.onload = function () {
                                                         var Now = new Date();
                                                         var currentYear = Now.getFullYear(); // 获取当前年份
                                                         var startTimeString = currentYear + "-05-14T15:16:17+08:00";
@@ -1234,7 +1226,7 @@ https://space.bilibili.com/2054654702/
                                                             const formattedDateTime = `${year}年${month}月${day}日 ${hours}时${minutes}分`;
 
                                                             // 替换 #123 为链接
-                                                            latestCommitMessage = latestCommitMessage.replace(/#(\d+)/g, function(match, issueNumber) {
+                                                            latestCommitMessage = latestCommitMessage.replace(/#(\d+)/g, function (match, issueNumber) {
                                                                 return `<a href="https://github.com/DuckDuckStudio/yazicbs.github.io/issues/${issueNumber}" target="_blank">${match}</a>`;
                                                             });
 
@@ -1259,7 +1251,7 @@ https://space.bilibili.com/2054654702/
                                                     style="font-size: 17px; letter-spacing: 0px;">
                                                     <b>标题</b>
                                                 </p>-->
-                                                <img src="https://duckduckstudio.github.io/yazicbs.github.io/font/做根号的自己.png" width="100%" height="100%" alt="做更好的自己">
+                                                <img src="https://duckduckstudio.github.io/yazicbs.github.io/font/做根号的自己.png" style="width: 100%; height: 100%;" alt="做更好的自己">
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
PyCharm:
- zh_cn/index.html
  - 废弃的特性: itemprop
  - 元素 ul 未闭合
  - 结束标记不匹配
- Tools/Fufu_Tools/wiki/常见问题QandA/小工具/index.html
  - 结束标记不匹配
- Interesting/KFCfkThurVMe50.html
  - HTTP 链接不安全
- Interesting/鸭子活了多久/index.html
  - 未知 HTML 标记 spen

Visual Studio:
- zh_cn/index.html
  - 元素“ul”需要结束标记。
  - 缺少与开始标记匹配的结束标记。
  - 元素“li”不能嵌套在元素“div”内。
  - “100%”不是特性“width”/“height”的有效值。
- Tools/Fufu_Tools/wiki/常见问题QandA/小工具/index.html
  - “70%”不是特性“width”/“height”的有效值。

Other:
- fix: 更新 中文Git 备用下载文件和信息

---

