### PR TITLE
fix: 改用 insertAdjacentHTML 保持 DOM 事件完整性

### DIFF
--- a/zh_cn/js/Festivals.mts
+++ b/zh_cn/js/Festivals.mts
@@ -29,7 +29,8 @@ if (日期对象 && 日期对象[2] && ((日期对象[1] === '腊月' && parseIn
     灯笼样式.href = 'https://duckduckstudio.github.io/yazicbs.github.io/zh_cn/css/灯笼.css'; 
     document.head.appendChild(灯笼样式); // 动态引入 CSS 文件
 
-    document.body.innerHTML += `
+    document.body.insertAdjacentHTML(
+        "beforeend", `
         <div class="deng-box1">
             <div class="deng">
                 <div class="xian"></div>
@@ -58,5 +59,5 @@ if (日期对象 && 日期对象[2] && ((日期对象[1] === '腊月' && parseIn
                 </div>
             </div>
         </div>
-    `; // 动态插入 HTML 内容
+    `);
 }


### PR DESCRIPTION
将 `document.body.innerHTML +=` 替换为 `document.body.insertAdjacentHTML('beforeend', ...)`

原方式会导致整个 `body` 被重写，移除所有现有的事件监听器，使 Aplayer 和一些东西停止工作。
新方式在 `body` 末尾插入新元素，而不影响现有 DOM 结构和事件绑定。