### PR TITLE
chore: 添加 npx serve 配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,9 @@ jobs:
           rm -v README.md
           rm -v Tools/chinese_git/notice/Notice.md
           rm -v tsconfig.json
+          rm -v package.json
+          rm -v package-lock.json
+          rm -v serve.json
 
       - name: 设置页面
         uses: actions/configure-pages@v5

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,3 @@
+{
+  "trailingSlash": true
+}


### PR DESCRIPTION
https://www.npmjs.com/package/serve
https://github.com/vercel/serve-handler#options
https://github.com/vercel/serve-handler?tab=readme-ov-file#trailingslash-boolean

该配置可以修复在通过不以斜杠结尾的链接访问时使用相对路径的资源 404 的问题。
如 `npx serve .` 后访问 `http://localhost:端口/zh_cn` 时
```log
 HTTP  2026/2/7 13:38:07 ::1 GET /css/optimize.css
 HTTP  2026/2/7 13:38:07 ::1 GET /js/SongList.mjs
 HTTP  2026/2/7 13:38:07 ::1 Returned 404 in 18 ms
 HTTP  2026/2/7 13:38:07 ::1 Returned 404 in 12 ms
```