### PR TITLE
chore(dependabot): 不再自动更新芙芙工具箱文档中的依赖要求文件

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,11 @@ updates:
     directory: ".action_scripts/Python/" # Location of package manifests
     schedule:
       interval: "daily"
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "Tools/Fufu_Tools/wiki/files/text/" # Location of package manifests
-    schedule:
-      interval: "daily"
+  # 芙芙工具箱已经归档很久了
+  # - package-ecosystem: "pip" # See documentation for possible values
+  #   directory: "Tools/Fufu_Tools/wiki/files/text/" # Location of package manifests
+  #   schedule:
+  #     interval: "daily"
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
芙芙工具箱已经归档 5 个月多了，我不想再处理它的依赖更新。

```py
>>> from datetime import date
>>>
>>> date1 = date(2025, 11, 23)
>>> date2 = date(2026, 4, 26)
>>> delta = date2 - date1
>>> delta.days
154
```